### PR TITLE
refactor: Simplify release artifacts to a single portable zip and upd…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,10 +121,6 @@ jobs:
     if: needs.version.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    strategy:
-      fail-fast: true
-      matrix:
-        rid: [linux-x64, win-x64, osx-arm64]
     steps:
       - uses: actions/checkout@v7
 
@@ -132,37 +128,42 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      - name: Publish ${{ matrix.rid }}
+      # One portable package, and deliberately no apphost. Without the native launcher a
+      # per-RID publish produces the same file set anyway, and a freshly built unsigned .exe
+      # with no download reputation gets flagged as Trojan:Script/Wacatac.B!ml.
+      - name: Publish
         shell: bash
         env:
           VERSION: ${{ needs.version.outputs.version }}
-          RID: ${{ matrix.rid }}
         run: |
           set -euo pipefail
           dotnet publish src/TargetApiSimulator/TargetApiSimulator.csproj \
             --configuration Release \
-            --runtime "$RID" \
-            --self-contained false \
+            -p:UseAppHost=false \
             -p:DebugType=embedded \
             -p:Version="$VERSION" \
             -p:InformationalVersion="$VERSION+$GITHUB_SHA" \
-            --output "out/$RID"
+            --output out/portable
+
+          if ls out/portable | grep -qiE '\.exe$'; then
+            echo "An .exe ended up in the package; UseAppHost=false is not taking effect." >&2
+            exit 1
+          fi
 
       - name: Package
         shell: bash
         env:
           VERSION: ${{ needs.version.outputs.version }}
-          RID: ${{ matrix.rid }}
         run: |
           set -euo pipefail
-          NAME="TargetApiSimulator-$VERSION-$RID"
+          NAME="TargetApiSimulator-$VERSION"
           mkdir -p dist
-          ( cd "out/$RID" && zip -r "$GITHUB_WORKSPACE/dist/$NAME.zip" . )
+          ( cd out/portable && zip -r "$GITHUB_WORKSPACE/dist/$NAME.zip" . )
           ( cd dist && sha256sum "$NAME.zip" > "$NAME.zip.sha256" )
 
       - uses: actions/upload-artifact@v7
         with:
-          name: package-${{ matrix.rid }}
+          name: package
           path: dist/*
           retention-days: 14
           if-no-files-found: error
@@ -178,8 +179,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v8
         with:
-          pattern: package-*
-          merge-multiple: true
+          name: package
           path: dist
 
       # Creates the tag at this commit as part of publishing, so VERSION.md stays the only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-First release under tag-driven versioning. Promote this section to `## [1.0.0] - YYYY-MM-DD`
-when the `develop -> master` pull request is merged and the tag is pushed.
+## [1.0.1] - 2026-07-31
+
+### Changed
+
+- Release artifacts ship as **one portable zip** with a `.sha256` checksum instead of three
+  per-platform ones, built with `-p:UseAppHost=false` so no executable is included. Microsoft
+  Defender flagged the 1.0.0 Windows zip as `Trojan:Script/Wacatac.B!ml` and quarantined it
+  mid-download — a machine-learning heuristic that fires on unsigned, freshly built executables
+  with no download reputation. Without the launcher a per-RID publish produces an identical file
+  set anyway, so three zips collapse into one. Run it with
+  `dotnet TargetApiSimulator.dll --urls http://localhost:5000` on any platform.
+- The release pipeline fails if an `.exe` ever reappears in the package, rather than publishing
+  an artifact that will be flagged again.
+
+### Added
+
+- README: one-line snippets for PowerShell and bash that fetch and start the latest release
+  through the GitHub API, so nothing has to be downloaded through a browser.
+
+## [1.0.0] - 2026-07-31
 
 ### Added
 
@@ -55,7 +73,7 @@ when the `develop -> master` pull request is merged and the tag is pushed.
 - Project moved to `src/TargetApiSimulator/`; tests live in `tests/TargetApiSimulator.Tests/`.
 - Dockerfile rewritten: one `publish` stage instead of a duplicated build, runs as the
   unprivileged `uid 1654`, OCI labels, and the version passed in as a build argument.
-- Release artifacts are now per-platform (`win-x64`, `linux-x64`, `osx-arm64`) with `.sha256`
+- Release artifacts are per-platform zips (`win-x64`, `linux-x64`, `osx-arm64`) with `.sha256`
   checksums, named after the version.
 - `appsettings.Development.json` now lowers log levels instead of duplicating
   `appsettings.json` verbatim.
@@ -91,3 +109,7 @@ when the `develop -> master` pull request is merged and the tag is pushed.
 - Container no longer runs as root.
 - Every pull request runs `dotnet list package --vulnerable --include-transitive` and fails on a
   hit. CLI output is forced to English so the check cannot silently pass on a localised runner.
+
+[Unreleased]: https://github.com/Mysttic/TargetApiSimulator/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/Mysttic/TargetApiSimulator/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/Mysttic/TargetApiSimulator/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,9 +48,9 @@ No tag is ever created by hand. [VERSION.md](./VERSION.md) drives everything.
    run summary whether merging will publish, and under which number.
 3. Merge with a **merge commit** (not squash — `master` keeps real merge commits).
 4. `release.yml` runs on that push to `master`. It reads `VERSION.md`, confirms `vX.Y.Z` does not
-   already exist, builds and tests, publishes zips for `win-x64`, `linux-x64` and `osx-arm64`
-   with `.sha256` files, **creates the tag**, publishes the GitHub Release, and pushes images
-   tagged `X.Y.Z`, `X.Y` and `latest` to GHCR and Docker Hub.
+   already exist, builds and tests, produces one portable zip with a `.sha256` file, **creates
+   the tag**, publishes the GitHub Release, and pushes images tagged `X.Y.Z`, `X.Y` and `latest`
+   to GHCR and Docker Hub.
 5. Back-merge so develop does not fall behind:
 
    ```bash
@@ -69,6 +69,22 @@ A tag pushed using the default `GITHUB_TOKEN` does not trigger further workflow 
 blocks that to prevent recursion. A design where one workflow pushes the tag and another listens
 for it would create the tag and then silently do nothing, unless a personal access token were
 introduced. Doing the tagging and the publishing in a single run avoids needing one.
+
+### No executable is shipped
+
+Release artifacts contain the managed assembly only — `-p:UseAppHost=false`. A freshly built,
+unsigned `.exe` with no download reputation is routinely flagged by antivirus machine-learning
+heuristics; Microsoft Defender reported the v1.0.0 Windows zip as `Trojan:Script/Wacatac.B!ml`,
+a heuristic verdict, and quarantined it mid-download.
+
+Dropping the launcher also removes the reason for per-platform zips: a framework-dependent
+publish without an apphost produces the same file set for every RID, so there is now one
+portable zip instead of three.
+
+Signing would be the other way to solve this. SignPath Foundation offers it free for open
+source, but it requires an application and approval, and the signature is issued in the
+foundation's name rather than the project's. Everything this project publishes stays on
+GitHub — no external package registry or account is involved.
 
 ### Dry run
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ and assert that what you send is well-formed JSON.
 
 | How you run it | URL to send requests to |
 |---|---|
-| `dotnet run` (default `http` profile) | `http://localhost:5274/api/target` |
-| `dotnet run --launch-profile https` | `https://localhost:7046/api/target` |
 | `docker run --rm -p 5000:8080 mysttic/targetapisimulator` | `http://localhost:5000/api/target` |
 | Release zip: `dotnet TargetApiSimulator.dll --urls http://localhost:5000` | `http://localhost:5000/api/target` |
+| `dotnet run` from a clone (default `http` profile) | `http://localhost:5274/api/target` |
+| `dotnet run --launch-profile https` | `https://localhost:7046/api/target` |
 
 A ready-to-run request collection is in [TargetApiSimulator.http](./TargetApiSimulator.http).
 
@@ -221,27 +221,40 @@ The container runs as an unprivileged user (`uid 1654`) and listens on 8080 only
 
 ## Get a release
 
-Each release on the [Releases page](https://github.com/Mysttic/TargetApiSimulator/releases) ships one zip per
-platform, plus a `.sha256` checksum next to it:
+Every release on the [Releases page](https://github.com/Mysttic/TargetApiSimulator/releases) ships one portable
+zip plus its `.sha256` checksum. The .NET 10 runtime has to be installed; the same zip then runs on Windows,
+Linux and macOS.
 
-| Asset | Run it with |
-|---|---|
-| `TargetApiSimulator-<version>-win-x64.zip` | `TargetApiSimulator.exe` |
-| `TargetApiSimulator-<version>-linux-x64.zip` | `./TargetApiSimulator` |
-| `TargetApiSimulator-<version>-osx-arm64.zip` | `./TargetApiSimulator` |
+Fetch and start the latest one in a single step — PowerShell:
 
-All builds are framework-dependent, so the .NET 10 runtime has to be installed. `dotnet TargetApiSimulator.dll`
-works from any of them regardless of platform.
-
-```bash
-./TargetApiSimulator --urls http://localhost:5000
+```powershell
+$tag = (Invoke-RestMethod https://api.github.com/repos/Mysttic/TargetApiSimulator/releases/latest).tag_name
+Invoke-WebRequest "https://github.com/Mysttic/TargetApiSimulator/releases/download/$tag/TargetApiSimulator-$($tag.TrimStart('v')).zip" -OutFile tas.zip
+Expand-Archive tas.zip -DestinationPath tas -Force
+dotnet tas/TargetApiSimulator.dll --urls http://localhost:5000
 ```
 
-Everything the application receives is printed to the console it runs in. Check the download first:
+bash:
 
 ```bash
-sha256sum -c TargetApiSimulator-1.0.0-linux-x64.zip.sha256
+TAG=$(curl -sL https://api.github.com/repos/Mysttic/TargetApiSimulator/releases/latest | grep -oP '"tag_name": "\K[^"]+')
+curl -sL "https://github.com/Mysttic/TargetApiSimulator/releases/download/$TAG/TargetApiSimulator-${TAG#v}.zip" -o tas.zip
+unzip -o tas.zip -d tas
+dotnet tas/TargetApiSimulator.dll --urls http://localhost:5000
 ```
+
+Verify the download if you want to:
+
+```bash
+sha256sum -c TargetApiSimulator-1.0.0.zip.sha256
+```
+
+> The zip deliberately contains **no `.exe` launcher**. A freshly built, unsigned executable with no download
+> reputation is routinely flagged by antivirus machine-learning heuristics — Microsoft Defender reports it as
+> `Trojan:Script/Wacatac.B!ml`. Shipping only the managed assembly removes the false positive entirely, at the
+> cost of typing `dotnet` in front of the command.
+
+Everything the application receives is printed to the console it runs in.
 
 ## Versioning
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,6 +1,6 @@
 # Version
 
-1.0.0
+1.0.1
 
 <!--
   This file is the single source of truth for the released version.


### PR DESCRIPTION
…ate documentation

## What

<!-- One sentence. This ends up in the release notes, so write it from the point of view of
     someone who uses the simulator. -->

## Contract impact

- Endpoint(s):
- Status code changed: yes / no
- Response body changed: yes / no
- If either is "yes" -> a MINOR or MAJOR bump is required, plus a note in the release notes.

## Checklist

- [ ] Targets `develop` (not `master`), unless this is a release or a hotfix
- [ ] `dotnet test` passes locally
- [ ] `dotnet format --verify-no-changes` is clean
- [ ] README updated if user-visible behaviour changed
- [ ] Validation contract table in README updated if the accepted/rejected set changed
- [ ] If this should ship: `VERSION.md` bumped and `CHANGELOG.md` has a section for that number

## How to verify

```bash
curl -i -X POST http://localhost:5274/api/target \
  -H 'Content-Type: application/json' -d '{"key":"value"}'
```
